### PR TITLE
set -eo pipefail

### DIFF
--- a/build-iso
+++ b/build-iso
@@ -22,6 +22,13 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+# NOTE: set -e stops the execution in the event of an error.
+
+# NOTE: set -o pipefail is needed to ensure that any error or failure causes the whole pipeline to fail.
+# Without this specification, the CI status will provide a false sense of security by showing builds
+# as succeeding in spite of errors or failures.
+set -eo pipefail
+
 VERSION="1.99.08"
 VERSION_DATE="May 13, 2022"
 


### PR DESCRIPTION
"set -e" stops the execution in the event of an error

"set -o pipefail" ensures that any error or failure causes the whole GitHub Workflows pipeline to fail.  Without this specification, it's possible for GitHub Workflows to paint an unsuccessful build as successful.