### PR TITLE
Added wait command just before set -eo pipefail

### DIFF
--- a/build-iso
+++ b/build-iso
@@ -28,6 +28,7 @@
 # Without this specification, the CI status will provide a false sense of security by showing builds
 # as succeeding in spite of errors or failures.
 if [ -n "$GITHUB_WORKSPACE" ]; then
+  wait # Generic command to keep in the event "set -eo pipefail" needs to be temporarily disabled.
   set -eo pipefail
   echo 'set -eo pipefail in GitHub Workflows environment'
 fi


### PR DESCRIPTION
The "set -eo pipefail" command is necessary to avoid the false sense of security of having the build pass in GitHub Workflows in spite of errors.  However, this also suppresses important screen outputs.

There will be times when it's necessary to temporarily disable set -eo pipefail for troubleshooting purposes.