### PR TITLE
ntp/ntpsec -> chrony

### DIFF
--- a/Template/COMMON/initrd/etc/init.d/live-disable-services
+++ b/Template/COMMON/initrd/etc/init.d/live-disable-services
@@ -39,6 +39,7 @@ LEAN_SERVICES="
     bluetooth
     bootlogs
     #cherokee
+    chrony
     cpufrequtils
     cron
     cups
@@ -50,7 +51,6 @@ LEAN_SERVICES="
     lvm2
     mdadm
     nfs-common
-    ntpsec
     ofono
     rpcbind
     rsync
@@ -101,7 +101,6 @@ MEAN_SERVICES="
     networking
     nfs-common
     nfs-kernel-server
-    ntp
     pppd-dns
     resolvconf
     rpcbind
@@ -179,7 +178,7 @@ do_start() {
         [ -z "${disable_param##*[m]*}" ] &&             MEAN=true
         [ -z "${disable_param##*[n]*}" ] &&      DISABLE_NFS=true
         [ -z "${disable_param##*[n]*}" ] &&       NFS_REASON=n
-        [ -z "${disable_param##*[N]*}" ] &&      ENABLE_NTPD=true
+        [ -z "${disable_param##*[N]*}" ] &&    ENABLE_CHRONY=true
         [ -z "${disable_param##*[P]*}" ] &&       ENABLE_PAM=true
         [ -z "${disable_param##*[v]*}" ] &&     DISABLE_VBOX=true
         [ -z "${disable_param##*[w]*}" ] &&             WICD=no
@@ -216,7 +215,7 @@ do_start() {
     fi
 
     [ "$ENABLE_BOOTCLEAN" ] || disable_services 'checkroot-bootclean disable by default' 'checkroot-bootclean.sh'
-    [ "$ENABLE_NTPD"      ] || disable_services "ntpd disable by default" ntp
+    [ "$ENABLE_CHRONY"      ] || disable_services "chrony disable by default" chrony
     [ "$ENABLE_PAM"       ] || disable_pam_login
     [ "$ENABLE_PLYMOUTH"  ] || disable_services 'plymouth' plymouth
 

--- a/Template/COMMON/initrd/etc/init.d/live-disable-services
+++ b/Template/COMMON/initrd/etc/init.d/live-disable-services
@@ -178,8 +178,8 @@ do_start() {
         [ -z "${disable_param##*[m]*}" ] &&             MEAN=true
         [ -z "${disable_param##*[n]*}" ] &&      DISABLE_NFS=true
         [ -z "${disable_param##*[n]*}" ] &&       NFS_REASON=n
-        [ -z "${disable_param##*[N]*}" ] &&    ENABLE_CHRONY=true
         [ -z "${disable_param##*[P]*}" ] &&       ENABLE_PAM=true
+        [ -z "${disable_param##*[T]*}" ] &&    ENABLE_CHRONY=true
         [ -z "${disable_param##*[v]*}" ] &&     DISABLE_VBOX=true
         [ -z "${disable_param##*[w]*}" ] &&             WICD=no
         [ -z "${disable_param##*[W]*}" ] &&             WICD=yes

--- a/Template/COMMON/initrd/live/README
+++ b/Template/COMMON/initrd/live/README
@@ -243,11 +243,11 @@ after you boot with the "services" command.
     L                Enabled syslogd service
     m [mean]         disable "mean" services (see below)
     n                disable nfs service
-    N                Enable chrony service (disbabled by default)
     P                Enable pamd service (disabled by default)
     r [norepo]       don't localize repos based on timezone
     s [nosavestate]  don't save state on live-usb systems
     S [savestate]    DO save state on live-usb systems
+    T                Enable chrony service (disbabled by default)
     v                disable VirtualBox services
     V                Don't blacklist fb modules, nvidiafb, etc.
       [vboxdecor]    Enable fbcondecor in Virtual Box

--- a/Template/COMMON/initrd/live/README
+++ b/Template/COMMON/initrd/live/README
@@ -243,7 +243,7 @@ after you boot with the "services" command.
     L                Enabled syslogd service
     m [mean]         disable "mean" services (see below)
     n                disable nfs service
-    N                Enable ntpd service (disbabled by default)
+    N                Enable chrony service (disbabled by default)
     P                Enable pamd service (disabled by default)
     r [norepo]       don't localize repos based on timezone
     s [nosavestate]  don't save state on live-usb systems
@@ -277,14 +277,13 @@ Xtralean Services (x):
 
 Mean Services (m):
 
-    avahi-daemon               nfs-kernel-server
-    dnsmasq                    ntp
+    avahi-daemon               nfs-common
+    dnsmasq                    nfs-kernel-server
     ifplugd                    pppd-dns
     mountnfs-bootclean.sh      resolvconf
     mountnfs.sh                rpcbind
     network-manager            smbd
     networking                 ufw
-    nfs-common
 
 
 Personalization

--- a/Template/COMMON/pesky-package.list
+++ b/Template/COMMON/pesky-package.list
@@ -2,7 +2,6 @@ firmware-ipw2x00
 udev-modified-init
 plymouth-modified-init
 brightness-modified-init
-ntpsec-modified-init
 cups
 printer-driver-cups-pdf
 grub-files-mx

--- a/Template/mx32/package.list
+++ b/Template/mx32/package.list
@@ -245,7 +245,6 @@ network-manager-openvpn-gnome
 #nitroshare
 nomacs
 nomacs-l10n
-#ntp
 #numix-gtk-theme
 #numix-icon-theme
 #nvidia-detect

--- a/Template/mx64/package.list
+++ b/Template/mx64/package.list
@@ -245,7 +245,6 @@ network-manager-openvpn-gnome
 #nitroshare
 nomacs
 nomacs-l10n
-#ntp
 #numix-gtk-theme
 #numix-icon-theme
 nvidia-detect

--- a/Template/mxahs/package.list
+++ b/Template/mxahs/package.list
@@ -246,7 +246,6 @@ network-manager-openvpn-gnome
 #nitroshare
 nomacs
 nomacs-l10n
-#ntp
 #numix-gtk-theme
 #numix-icon-theme
 nvidia-detect

--- a/Template/mxbase32/package.list
+++ b/Template/mxbase32/package.list
@@ -220,7 +220,6 @@ network-manager-openvpn-gnome
 #nictools-pci
 #nomacs
 #nomacs-l10n
-#ntp
 #numix-gtk-theme
 #numix-icon-theme
 #nvidia-detect

--- a/Template/mxbase64/package.list
+++ b/Template/mxbase64/package.list
@@ -221,7 +221,6 @@ network-manager-openvpn-gnome
 #nictools-pci
 #nomacs
 #nomacs-l10n
-#ntp
 #numix-gtk-theme
 #numix-icon-theme
 nvidia-detect


### PR DESCRIPTION
Replace ntp/ntpsec reminants with chrony equivalent.
The original ntpd isn't even available for Bookworm.